### PR TITLE
Fix bug in conditional that checked if an argument was provided

### DIFF
--- a/started-on-current-tty.sh
+++ b/started-on-current-tty.sh
@@ -19,7 +19,13 @@ function usage()
 }
 
 # Check that at least one argument has been provided
-[ $# != 1 ] && ( usage && exit -1 ) || process=$1;
+if [ $# != 1 ]; then
+    usage 
+    exit -1 
+fi
+
+# Get the name of the desired process
+process=$1;
 
 # Get the current tty
 current_tty=$(tty)


### PR DESCRIPTION
Previously, the conditional that checked if an argument was provided
didn't work correctly and crashed out if an argument wasn't provided,
rather than printing the usage message and exiting. This change fixes
this behaviour.